### PR TITLE
Add gateway order and product DTOs

### DIFF
--- a/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/OrderRequestDto.java
+++ b/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/OrderRequestDto.java
@@ -11,12 +11,9 @@ import java.math.BigDecimal;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class OrderDto {
-    private Long id;
+public class OrderRequestDto {
     private BigDecimal price;
     private String category;
     private String item;
     private Integer quantity;
-    private BigDecimal netAmount;
-    private String status;
 }

--- a/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/ProductDto.java
+++ b/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/ProductDto.java
@@ -1,0 +1,19 @@
+package com.pooranjoyb.graphql.gateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductDto {
+    private String name;
+    private Boolean inStock;
+    private String image;
+    private String description;
+    private String brand;
+    private Long rating;
+}

--- a/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/ProductRequestDto.java
+++ b/graphql.gateway/src/main/java/com/pooranjoyb/graphql/gateway/dto/ProductRequestDto.java
@@ -1,0 +1,20 @@
+package com.pooranjoyb.graphql.gateway.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductRequestDto {
+    private String name;
+    private Long stock;
+    private String image;
+    private String description;
+    private String brand;
+    private Long rating;
+    private Long sku;
+}

--- a/graphql.gateway/src/test/java/com/pooranjoyb/graphql/gateway/dto/GatewayDtoTests.java
+++ b/graphql.gateway/src/test/java/com/pooranjoyb/graphql/gateway/dto/GatewayDtoTests.java
@@ -1,0 +1,74 @@
+package com.pooranjoyb.graphql.gateway.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class GatewayDtoTests {
+
+    @Test
+    void orderRequestDtoCarriesOrderServicePayloadFields() {
+        OrderRequestDto request = OrderRequestDto.builder()
+                .price(BigDecimal.valueOf(199.99))
+                .category("electronics")
+                .item("keyboard")
+                .quantity(2)
+                .build();
+
+        assertThat(request.getPrice()).isEqualByComparingTo("199.99");
+        assertThat(request.getCategory()).isEqualTo("electronics");
+        assertThat(request.getItem()).isEqualTo("keyboard");
+        assertThat(request.getQuantity()).isEqualTo(2);
+    }
+
+    @Test
+    void orderDtoCarriesOrderServiceResponseFields() {
+        OrderDto response = OrderDto.builder()
+                .id(42L)
+                .price(BigDecimal.valueOf(100))
+                .category("books")
+                .item("architecture guide")
+                .quantity(1)
+                .netAmount(BigDecimal.valueOf(100))
+                .status("CREATED")
+                .build();
+
+        assertThat(response.getId()).isEqualTo(42L);
+        assertThat(response.getNetAmount()).isEqualByComparingTo("100");
+        assertThat(response.getStatus()).isEqualTo("CREATED");
+    }
+
+    @Test
+    void productRequestDtoCarriesProductServicePayloadFields() {
+        ProductRequestDto request = ProductRequestDto.builder()
+                .name("monitor")
+                .stock(10L)
+                .image("monitor.png")
+                .description("27 inch display")
+                .brand("Acme")
+                .rating(5L)
+                .sku(12345L)
+                .build();
+
+        assertThat(request.getName()).isEqualTo("monitor");
+        assertThat(request.getStock()).isEqualTo(10L);
+        assertThat(request.getSku()).isEqualTo(12345L);
+    }
+
+    @Test
+    void productDtoCarriesProductServiceResponseFields() {
+        ProductDto response = ProductDto.builder()
+                .name("monitor")
+                .inStock(true)
+                .image("monitor.png")
+                .description("27 inch display")
+                .brand("Acme")
+                .rating(5L)
+                .build();
+
+        assertThat(response.getName()).isEqualTo("monitor");
+        assertThat(response.getInStock()).isTrue();
+        assertThat(response.getBrand()).isEqualTo("Acme");
+    }
+}


### PR DESCRIPTION
## Summary
- add gateway order request DTO aligned with `order.service` create/update payloads
- add gateway product request/response DTOs aligned with `product.service` payloads
- keep the existing order response DTO shape consistent and add focused DTO contract tests

Closes #25

## Testing
- Added `GatewayDtoTests` for order/product request and response DTO contracts
- `./mvnw test` could not be executed locally because this machine does not have a Java runtime installed (`Unable to locate a Java Runtime`). The change is limited to Lombok DTOs and JUnit DTO contract tests.

## NSoC Labels Requested
Please add/keep `nsoc26` and `level3` if accepted.